### PR TITLE
Fix typo: change some description in slack.md

### DIFF
--- a/community/slack.md
+++ b/community/slack.md
@@ -1,19 +1,19 @@
 ---
-title: 加入微信交流群
+title: 加入 Slack 群组
 slug: /community/slack
 tags:
   - 社区
   - Slack
-description: 加入 OSS-Compass 社区微信交流群
+description: 加入 OSS-Compass Slack 群组
 ---
 
 你可以通过点击下面的按钮加入我们的 Slack 频道。
 
-[![加入微信交流群](media/slack.jpg)](https://join.slack.com/t/slack-vit2156/shared_invite/zt-1hv9pabzr-80W3QeM4zABSJFWEmPNipw)
+[![加入Slack 群组](media/slack.jpg)](https://join.slack.com/t/slack-vit2156/shared_invite/zt-1hv9pabzr-80W3QeM4zABSJFWEmPNipw)
 
 如果点击按钮无效，你可以复制点击或复制以下 URL 到浏览器。
 
-:::info 加入我们的微信交流群
+:::info 加入我们的Slack 群组
 
 <https://join.slack.com/t/slack-vit2156/shared_invite/zt-1hv9pabzr-80W3QeM4zABSJFWEmPNipw>
 


### PR DESCRIPTION
All "微信交流群" appeared in slack.md should be "slack " or "slack group"，this commit fix it.

Signed-off-by: Guoqiang QI <guoqiang.qi1@gmail.com>